### PR TITLE
VSCode config + debuggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 package-lock.json
 
 report.*.json
+
+# .vscode Debugging
+.vscode/*-debug-profile

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,6 @@
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "firefox-devtools.vscode-firefox-debug",
-    "msjsdiag.debugger-for-chrome",
-    "stylelint.vscode-stylelint"
+    "msjsdiag.debugger-for-chrome"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "bradlc.vscode-tailwindcss",
+    "dbaeumer.vscode-eslint",
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode",
+    "firefox-devtools.vscode-firefox-debug",
+    "msjsdiag.debugger-for-chrome",
+    "stylelint.vscode-stylelint"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,4 +1,7 @@
 {
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Next: Node",
+      "runtimeExecutable": "${workspaceFolder}\\node_modules\\.bin\\next",
+      "port": 9229,
+      "console": "integratedTerminal"
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Next: Chrome",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}",
+      "userDataDir": "${workspaceFolder}/.vscode/chrome-debug-profile"
+    },
+    {
+      "type": "firefox",
+      "request": "launch",
+      "name": "Next: Firefox",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}",
+      "profileDir": "${workspaceFolder}/.vscode/firefox-debug-profile",
+      "keepProfileChanges": true
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Next: Full",
+      "configurations": ["Next: Node", "Next: Chrome"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "editor.formatOnPaste": true,
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "label": "npm: build",
+      "detail": "next build"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npx create-r3f-app next my-app
 - [x] Layout for Canvas and DOM
 - [x] Template for the meta data and header
 - [x] Clean code using ESlint, Prettier and Husky
+- [x] VSCode debug profiles for the server, Chrome, and Firefox
 
 ### :bullettrain_side: Architecture
 


### PR DESCRIPTION
Adds:

- Chrome/Firefox debug profiles
- Extension recommendations
- Configures default `SUPER+Shift+B` shortcut to run `npm run build`
- Recommends relevant extensions