### PR TITLE
pass page props to cildren with example

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -30,7 +30,7 @@ function MyApp({ Component, pageProps }) {
 
   let r3fArr = []
   let compArr = []
-  Children.forEach(Component().props.children, (child) => {
+  Children.forEach(Component(pageProps).props.children, (child) => {
     if (child.props && child.props.r3f) {
       r3fArr.push(child)
     } else {
@@ -43,7 +43,7 @@ function MyApp({ Component, pageProps }) {
   }, [router])
 
   return r3fArr.length > 0 ? (
-    <SplitApp canvas={r3fArr} dom={compArr} {...pageProps} />
+    <SplitApp canvas={r3fArr} dom={compArr} />
   ) : (
     <Component {...pageProps} />
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,8 +6,8 @@ const Sphere = dynamic(() => import('@/components/canvas/Sphere'), {
   ssr: false,
 })
 
-const Page = () => {
-  useStore.setState({ title: 'Sphere' })
+const Page = ({ title }) => {
+  useStore.setState({ title })
   return (
     <>
       <Sphere r3f />
@@ -17,3 +17,11 @@ const Page = () => {
 }
 
 export default Page
+
+export async function getStaticProps() {
+  return {
+    props: {
+      title: 'Sphere',
+    },
+  }
+}


### PR DESCRIPTION
This passes the pageProps through to the page component. SplitApp doesn't actually make the pageProps available on a page (eg on `pages/index.js`). Used `getStaticProps` on `pages/index.js` to set the title as an example.