### PR TITLE
wip do not merge : a11y basic implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ export default Page
 
 - [`threejs`](https://github.com/mrdoob/three.js/) &ndash; A lightweight, 3D library with a default WebGL renderer.
 - [`react-three-fiber`](https://github.com/pmndrs/react-three-fiber) &ndash; A React renderer for Threejs on the web and react-native.
-- [`@react-three/drei`](https://github.com/react-spring/drei) &ndash; useful helpers for react-three-fiber
+- [`@react-three/drei`](https://github.com/pmndrs/drei) &ndash; useful helpers for react-three-fiber
+- [`@react-three/a11y`](https://github.com/pmndrs/react-three-a11y/) &ndash; Accessibility tools for React Three Fiber
 - [`tailwind`](https://tailwindcss.com/docs) &ndash; A utility-first CSS framework packed with classes like flex, pt-4, text-center and rotate-90 directly in your markup.
 - [`r3f-perf`](https://github.com/RenaudRohlinger/r3f-perf) &ndash; Tool to easily monitor react threejs performances.
 - [`@three-material-editor`](https://github.com/RenaudRohlinger/three-material-editor) &ndash; Tool to easily edit the shaders of your threejs materials.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "next dev",
     "build": "next build",
     "export": "EXPORT=true next build && EXPORT=true next export",
-    "analyze": "ANALYZE=true next build",
+    "analyze": "cross-env ANALYZE=true next build",
     "start": "next start",
     "postinstall": "husky install"
   },
@@ -32,8 +32,8 @@
   "dependencies": {
     "@pmndrs/branding": "^0.0.7",
     "@react-spring/three": "^9.0.0-rc.3",
-    "@react-three/a11y": "^1.0.0",
-    "@react-three/drei": "^4.0.0-beta.3",
+    "@react-three/a11y": "1.0.1",
+    "@react-three/drei": "^4.0.0-beta.4",
     "@react-three/postprocessing": "^1.5.1",
     "lerp": "^1.0.3",
     "next": "^10.0.8",
@@ -54,6 +54,7 @@
     "autoprefixer": "^10.2.4",
     "babel-eslint": "^10.0.0",
     "babel-plugin-glsl": "^1.0.0",
+    "cross-env": "^7.0.3",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-config-react-app": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@pmndrs/branding": "^0.0.7",
     "@react-spring/three": "^9.0.0-rc.3",
+    "@react-three/a11y": "^1.0.0",
     "@react-three/drei": "^4.0.0-beta.3",
     "@react-three/postprocessing": "^1.5.1",
     "lerp": "^1.0.3",

--- a/src/components/canvas/Box.js
+++ b/src/components/canvas/Box.js
@@ -16,15 +16,20 @@ const BoxComponent = () => {
   return (
     <Suspense fallback={null}>
       <ambientLight intensity={0.5} />
-      <mesh
-        rotation={[45, 45, 45]}
-        onClick={() => {
+      <A11y
+        role="link"
+        href="/"
+        actionCall={()=>{
           router.push(`/`)
         }}
       >
-        <roundedBoxGeometry args={[1.5, 1.5, 1.5, 10, 0.1]} />
-        <M factor={3} color={color} />
-      </mesh>
+        <mesh
+          rotation={[45, 45, 45]}
+        >
+          <roundedBoxGeometry args={[1.5, 1.5, 1.5, 10, 0.1]} />
+          <M factor={3} color={color} />
+        </mesh>
+      </A11y>
       <Environment preset={'studio'} />
     </Suspense>
   )

--- a/src/components/canvas/Box.js
+++ b/src/components/canvas/Box.js
@@ -20,7 +20,7 @@ const RoundedDarkBox = () => {
     rotation={[45, 45, 45]}
   >
     <roundedBoxGeometry args={[1.5, 1.5, 1.5, 10, 0.1]} />
-  <M distort={a11yPrefersState.prefersReducedMotion ? 0 : 0.4} color={color} />
+    <M distort={a11yPrefersState.prefersReducedMotion ? 0 : 0.4} color={color} />
   </mesh>
   )
 }

--- a/src/components/canvas/Box.js
+++ b/src/components/canvas/Box.js
@@ -4,16 +4,29 @@ import { a, useSpring } from '@react-spring/three'
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry'
 import { extend } from 'react-three-fiber'
 import useStore from '@/helpers/store'
-import { A11y } from "@react-three/a11y"
+import { A11y, useA11y, useUserPreferences } from "@react-three/a11y"
 
 const M = a(MeshDistortMaterial)
 extend({ RoundedBoxGeometry })
 
+const RoundedDarkBox = () => {
+  const { a11yPrefersState } = useUserPreferences()
+  const a11y = useA11y()
+  const { color } = useSpring({
+    color: a11y.focus || a11y.hover ? '#494949' : '#272727',
+  })
+  return (
+    <mesh
+    rotation={[45, 45, 45]}
+  >
+    <roundedBoxGeometry args={[1.5, 1.5, 1.5, 10, 0.1]} />
+  <M distort={a11yPrefersState.prefersReducedMotion ? 0 : 0.4} color={color} />
+  </mesh>
+  )
+}
+
 const BoxComponent = () => {
   const router = useStore((s) => s.router)
-  const { color } = useSpring({
-    color: router.route !== '/box' ? 'black' : '#272727',
-  })
   return (
     <Suspense fallback={null}>
       <ambientLight intensity={0.5} />
@@ -24,12 +37,7 @@ const BoxComponent = () => {
           router.push(`/`)
         }}
       >
-        <mesh
-          rotation={[45, 45, 45]}
-        >
-          <roundedBoxGeometry args={[1.5, 1.5, 1.5, 10, 0.1]} />
-          <M factor={3} color={color} />
-        </mesh>
+        <RoundedDarkBox />
       </A11y>
       <Environment preset={'studio'} />
     </Suspense>

--- a/src/components/canvas/Box.js
+++ b/src/components/canvas/Box.js
@@ -4,7 +4,7 @@ import { a, useSpring } from '@react-spring/three'
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry'
 import { extend } from 'react-three-fiber'
 import useStore from '@/helpers/store'
-import { A11y, useA11y, useUserPreferences } from "@react-three/a11y"
+import { A11y, useA11y, useUserPreferences } from '@react-three/a11y'
 
 const M = a(MeshDistortMaterial)
 extend({ RoundedBoxGeometry })
@@ -16,12 +16,13 @@ const RoundedDarkBox = () => {
     color: a11y.focus || a11y.hover ? '#494949' : '#272727',
   })
   return (
-    <mesh
-    rotation={[45, 45, 45]}
-  >
-    <roundedBoxGeometry args={[1.5, 1.5, 1.5, 10, 0.1]} />
-    <M distort={a11yPrefersState.prefersReducedMotion ? 0 : 0.4} color={color} />
-  </mesh>
+    <mesh rotation={[45, 45, 45]}>
+      <roundedBoxGeometry args={[1.5, 1.5, 1.5, 10, 0.1]} />
+      <M
+        distort={a11yPrefersState.prefersReducedMotion ? 0 : 0.4}
+        color={color}
+      />
+    </mesh>
   )
 }
 
@@ -29,11 +30,10 @@ const BoxComponent = () => {
   const router = useStore((s) => s.router)
   return (
     <Suspense fallback={null}>
-      <ambientLight intensity={0.5} />
       <A11y
-        role="link"
-        href="/"
-        actionCall={()=>{
+        role='link'
+        href='/'
+        actionCall={() => {
           router.push(`/`)
         }}
       >

--- a/src/components/canvas/Box.js
+++ b/src/components/canvas/Box.js
@@ -4,6 +4,7 @@ import { a, useSpring } from '@react-spring/three'
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry'
 import { extend } from 'react-three-fiber'
 import useStore from '@/helpers/store'
+import { A11y } from "@react-three/a11y"
 
 const M = a(MeshDistortMaterial)
 extend({ RoundedBoxGeometry })

--- a/src/components/canvas/Sphere.js
+++ b/src/components/canvas/Sphere.js
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { Environment, MeshDistortMaterial, Sphere } from '@react-three/drei'
 import { a, useSpring } from '@react-spring/three'
 import useStore from '@/helpers/store'
-import { A11y, useA11y, useUserPreferences } from "@react-three/a11y"
+import { A11y, useA11y, useUserPreferences } from '@react-three/a11y'
 
 const M = a(MeshDistortMaterial)
 
@@ -13,10 +13,11 @@ const DarkSphere = () => {
     color: a11y.focus || a11y.hover ? '#272727' : 'black',
   })
   return (
-    <Sphere
-      args={[1, 32, 32]}
-    >
-      <M distort={a11yPrefersState.prefersReducedMotion ? 0 : 0.4} color={color} />
+    <Sphere args={[1, 32, 32]}>
+      <M
+        distort={a11yPrefersState.prefersReducedMotion ? 0 : 0.4}
+        color={color}
+      />
     </Sphere>
   )
 }
@@ -25,11 +26,10 @@ const SphereComponent = () => {
   const router = useStore((s) => s.router)
   return (
     <Suspense fallback={null}>
-      <ambientLight intensity={0.5} />
       <A11y
-        role="link"
-        href="/box"
-        actionCall={()=>{
+        role='link'
+        href='/box'
+        actionCall={() => {
           router.push(`/box`)
         }}
       >

--- a/src/components/canvas/Sphere.js
+++ b/src/components/canvas/Sphere.js
@@ -2,15 +2,27 @@ import { Suspense } from 'react'
 import { Environment, MeshDistortMaterial, Sphere } from '@react-three/drei'
 import { a, useSpring } from '@react-spring/three'
 import useStore from '@/helpers/store'
-import { A11y } from "@react-three/a11y"
+import { A11y, useA11y, useUserPreferences } from "@react-three/a11y"
 
 const M = a(MeshDistortMaterial)
 
+const DarkSphere = () => {
+  const { a11yPrefersState } = useUserPreferences()
+  const a11y = useA11y()
+  const { color } = useSpring({
+    color: a11y.focus || a11y.hover ? '#272727' : 'black',
+  })
+  return (
+    <Sphere
+      args={[1, 32, 32]}
+    >
+      <M distort={a11yPrefersState.prefersReducedMotion ? 0 : 0.4} color={color} />
+    </Sphere>
+  )
+}
+
 const SphereComponent = () => {
   const router = useStore((s) => s.router)
-  const { color } = useSpring({
-    color: router.route === '/box' ? '#272727' : 'black',
-  })
   return (
     <Suspense fallback={null}>
       <ambientLight intensity={0.5} />
@@ -21,11 +33,7 @@ const SphereComponent = () => {
           router.push(`/box`)
         }}
       >
-        <Sphere
-          args={[1, 32, 32]}
-        >
-          <M factor={2} color={color} />
-        </Sphere>
+        <DarkSphere />
       </A11y>
       <Environment preset={'studio'} />
     </Suspense>

--- a/src/components/canvas/Sphere.js
+++ b/src/components/canvas/Sphere.js
@@ -13,14 +13,19 @@ const SphereComponent = () => {
   return (
     <Suspense fallback={null}>
       <ambientLight intensity={0.5} />
-      <Sphere
-        args={[1, 32, 32]}
-        onClick={() => {
+      <A11y
+        role="link"
+        href="/box"
+        actionCall={()=>{
           router.push(`/box`)
         }}
       >
-        <M factor={2} color={color} />
-      </Sphere>
+        <Sphere
+          args={[1, 32, 32]}
+        >
+          <M factor={2} color={color} />
+        </Sphere>
+      </A11y>
       <Environment preset={'studio'} />
     </Suspense>
   )

--- a/src/components/canvas/Sphere.js
+++ b/src/components/canvas/Sphere.js
@@ -2,6 +2,7 @@ import { Suspense } from 'react'
 import { Environment, MeshDistortMaterial, Sphere } from '@react-three/drei'
 import { a, useSpring } from '@react-spring/three'
 import useStore from '@/helpers/store'
+import { A11y } from "@react-three/a11y"
 
 const M = a(MeshDistortMaterial)
 

--- a/src/components/dom/back.js
+++ b/src/components/dom/back.js
@@ -2,10 +2,8 @@ import Link from 'next/link'
 
 const BackButton = () => {
   return (
-    <Link href='/' as={`/`}>
-      <button className='absolute z-20 p-2 m-2 text-white focus:outline-none focus:ring'>
-        Previous page
-      </button>
+    <Link href='/' as={`/`} >
+      <a className='absolute z-20 p-2 m-2 text-white focus:outline-none focus:ring'>Previous page</a>
     </Link>
   )
 }

--- a/src/components/dom/go.js
+++ b/src/components/dom/go.js
@@ -2,10 +2,8 @@ import Link from 'next/link'
 
 const Go = () => {
   return (
-    <Link href='/box' as={`/box`}>
-      <button className='absolute z-20 p-2 m-2 text-white focus:outline-none focus:ring'>
-        Next page
-      </button>
+    <Link href='/box' as={`/box`} >
+        <a className='absolute z-20 p-2 m-2 text-white focus:outline-none focus:ring' >Next page</a>
     </Link>
   )
 }

--- a/src/components/layout/_canvas.js
+++ b/src/components/layout/_canvas.js
@@ -5,6 +5,7 @@ import { OrbitControls, Preload, useContextBridge } from '@react-three/drei'
 import { A11yUserPreferencesContext } from '@react-three/a11y'
 import { a, useSpring } from '@react-spring/three'
 import { EffectComposer, Vignette } from '@react-three/postprocessing'
+import { A11yUserPreferences } from '@react-three/a11y'
 
 const Bg = () => {
   const router = useStore((state) => state.router)
@@ -16,26 +17,28 @@ const Bg = () => {
 const LCanvas = ({ children }) => {
   const A11yContextBridge = useContextBridge(A11yUserPreferencesContext)
   return (
-    <Canvas
-      style={{
-        position: 'absolute',
-        top: 0,
-      }}
-      onCreated={({ events }) => {
-        useStore.setState({ events })
-      }}
-    >
-      <A11yContextBridge>
-        <Preload all />
-        <Bg />
-        <Perf openByDefault trackGPU={true} position={'bottom-right'} />
-        <OrbitControls />
-        <EffectComposer>
-          <Vignette eskil={false} offset={0.1} darkness={1.1} />
-        </EffectComposer>
-        {children}
-      </A11yContextBridge>
-    </Canvas>
+    <A11yUserPreferences>
+      <Canvas
+        style={{
+          position: 'absolute',
+          top: 0,
+        }}
+        onCreated={({ events }) => {
+          useStore.setState({ events })
+        }}
+      >
+        <A11yContextBridge>
+          <Preload all />
+          <Bg />
+          <Perf openByDefault trackGPU={true} position={'bottom-right'} />
+          <OrbitControls />
+          <EffectComposer>
+            <Vignette eskil={false} offset={0.1} darkness={1.1} />
+          </EffectComposer>
+          {children}
+        </A11yContextBridge>
+      </Canvas>
+    </A11yUserPreferences>
   )
 }
 

--- a/src/components/layout/_canvas.js
+++ b/src/components/layout/_canvas.js
@@ -1,8 +1,7 @@
 import { Canvas } from 'react-three-fiber'
 import { Perf } from 'r3f-perf'
 import useStore from '@/helpers/store'
-import { OrbitControls, Preload, useContextBridge } from '@react-three/drei'
-import { A11yUserPreferencesContext } from '@react-three/a11y'
+import { OrbitControls, Preload } from '@react-three/drei'
 import { a, useSpring } from '@react-spring/three'
 import { EffectComposer, Vignette } from '@react-three/postprocessing'
 import { A11yUserPreferences } from '@react-three/a11y'
@@ -15,30 +14,27 @@ const Bg = () => {
   return <a.color attach='background' r={bg} g={bg} b={bg} />
 }
 const LCanvas = ({ children }) => {
-  const A11yContextBridge = useContextBridge(A11yUserPreferencesContext)
   return (
-    <A11yUserPreferences>
-      <Canvas
-        style={{
-          position: 'absolute',
-          top: 0,
-        }}
-        onCreated={({ events }) => {
-          useStore.setState({ events })
-        }}
-      >
-        <A11yContextBridge>
-          <Preload all />
-          <Bg />
-          <Perf openByDefault trackGPU={true} position={'bottom-right'} />
-          <OrbitControls />
-          <EffectComposer>
-            <Vignette eskil={false} offset={0.1} darkness={1.1} />
-          </EffectComposer>
-          {children}
-        </A11yContextBridge>
-      </Canvas>
-    </A11yUserPreferences>
+    <Canvas
+      style={{
+        position: 'absolute',
+        top: 0,
+      }}
+      onCreated={({ events }) => {
+        useStore.setState({ events })
+      }}
+    >
+      <A11yUserPreferences>
+        <Preload all />
+        <Bg />
+        <Perf openByDefault trackGPU={true} position={'bottom-right'} />
+        <OrbitControls />
+        <EffectComposer>
+          <Vignette eskil={false} offset={0.1} darkness={1.1} />
+        </EffectComposer>
+        {children}
+      </A11yUserPreferences>
+    </Canvas>
   )
 }
 

--- a/src/components/layout/_canvas.js
+++ b/src/components/layout/_canvas.js
@@ -1,7 +1,8 @@
 import { Canvas } from 'react-three-fiber'
 import { Perf } from 'r3f-perf'
 import useStore from '@/helpers/store'
-import { OrbitControls, Preload } from '@react-three/drei'
+import { OrbitControls, Preload, useContextBridge } from '@react-three/drei'
+import { A11yUserPreferencesContext } from "@react-three/a11y"
 import { a, useSpring } from '@react-spring/three'
 import { EffectComposer, Vignette } from '@react-three/postprocessing'
 
@@ -13,6 +14,7 @@ const Bg = () => {
   return <a.color attach='background' r={bg} g={bg} b={bg} />
 }
 const LCanvas = ({ children }) => {
+  const ContextBridge = useContextBridge(A11yUserPreferencesContext)
   return (
     <Canvas
       style={{
@@ -23,14 +25,16 @@ const LCanvas = ({ children }) => {
         useStore.setState({ events })
       }}
     >
-      <Preload all />
-      <Bg />
-      <Perf openByDefault trackGPU={true} position={'bottom-right'} />
-      <OrbitControls />
-      <EffectComposer>
-        <Vignette eskil={false} offset={0.1} darkness={1.1} />
-      </EffectComposer>
-      {children}
+      <ContextBridge>
+        <Preload all />
+        <Bg />
+        <Perf openByDefault trackGPU={true} position={'bottom-right'} />
+        <OrbitControls />
+        <EffectComposer>
+          <Vignette eskil={false} offset={0.1} darkness={1.1} />
+        </EffectComposer>
+        {children}
+      </ContextBridge>
     </Canvas>
   )
 }

--- a/src/components/layout/_canvas.js
+++ b/src/components/layout/_canvas.js
@@ -2,7 +2,7 @@ import { Canvas } from 'react-three-fiber'
 import { Perf } from 'r3f-perf'
 import useStore from '@/helpers/store'
 import { OrbitControls, Preload, useContextBridge } from '@react-three/drei'
-import { A11yUserPreferencesContext } from "@react-three/a11y"
+import { A11yUserPreferencesContext } from '@react-three/a11y'
 import { a, useSpring } from '@react-spring/three'
 import { EffectComposer, Vignette } from '@react-three/postprocessing'
 
@@ -14,7 +14,7 @@ const Bg = () => {
   return <a.color attach='background' r={bg} g={bg} b={bg} />
 }
 const LCanvas = ({ children }) => {
-  const ContextBridge = useContextBridge(A11yUserPreferencesContext)
+  const A11yContextBridge = useContextBridge(A11yUserPreferencesContext)
   return (
     <Canvas
       style={{
@@ -25,7 +25,7 @@ const LCanvas = ({ children }) => {
         useStore.setState({ events })
       }}
     >
-      <ContextBridge>
+      <A11yContextBridge>
         <Preload all />
         <Bg />
         <Perf openByDefault trackGPU={true} position={'bottom-right'} />
@@ -34,7 +34,7 @@ const LCanvas = ({ children }) => {
           <Vignette eskil={false} offset={0.1} darkness={1.1} />
         </EffectComposer>
         {children}
-      </ContextBridge>
+      </A11yContextBridge>
     </Canvas>
   )
 }

--- a/src/components/layout/_dom.js
+++ b/src/components/layout/_dom.js
@@ -19,7 +19,7 @@ const Dom = ({ dom }) => {
       <h1 className='absolute w-full text-xs tracking-wider text-center text-white text-gray-100 md:mt-56 mt-28 top-1/2 sm:subpixel-antialiased md:antialiased'>
         REACT THREE NEXT STARTER
       </h1>
-      <div className='absolute bottom-4 right-4 z-index-30'>
+      <div className='absolute p-2 m-2 right-4 z-index-30'>
         <Badge />
       </div>
     </div>

--- a/src/components/layout/_dom.js
+++ b/src/components/layout/_dom.js
@@ -16,7 +16,7 @@ const Dom = ({ dom }) => {
     <div className='absolute top-0 left-0 right-0 z-20 dom' {...events}>
       <Header />
       {dom}
-      <h1 className='absolute w-full text-xs tracking-wider text-center text-white text-gray-100 md:mt-56 mt-28 top-1/2 sm:subpixel-antialiased md:antialiased'>
+      <h1 className='absolute w-full text-xs tracking-wider text-center text-gray-100 md:mt-56 mt-28 top-1/2 sm:subpixel-antialiased md:antialiased'>
         REACT THREE NEXT STARTER
       </h1>
       <div className='absolute p-2 m-2 right-4 z-index-30'>

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -4,7 +4,7 @@ import { useEffect, Children } from 'react'
 import Header from '../config'
 import dynamic from 'next/dynamic'
 import Dom from '@/components/layout/_dom'
-import { A11yUserPreferences } from "@react-three/a11y"
+import { A11yUserPreferences } from '@react-three/a11y'
 
 import '@/styles/index.css'
 
@@ -46,13 +46,11 @@ function MyApp({ Component, pageProps }) {
 
   return (
     <A11yUserPreferences>
-    {
-      r3fArr.length > 0 ? (
+      {r3fArr.length > 0 ? (
         <SplitApp canvas={r3fArr} dom={compArr} />
       ) : (
         <Component {...pageProps} />
-      )
-    }
+      )}
     </A11yUserPreferences>
   )
 }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -4,7 +4,6 @@ import { useEffect, Children } from 'react'
 import Header from '../config'
 import dynamic from 'next/dynamic'
 import Dom from '@/components/layout/_dom'
-import { A11yUserPreferences } from '@react-three/a11y'
 
 import '@/styles/index.css'
 
@@ -44,14 +43,10 @@ function MyApp({ Component, pageProps }) {
     useStore.setState({ router })
   }, [router])
 
-  return (
-    <A11yUserPreferences>
-      {r3fArr.length > 0 ? (
-        <SplitApp canvas={r3fArr} dom={compArr} />
-      ) : (
-        <Component {...pageProps} />
-      )}
-    </A11yUserPreferences>
+  return r3fArr.length > 0 ? (
+    <SplitApp canvas={r3fArr} dom={compArr} />
+  ) : (
+    <Component {...pageProps} />
   )
 }
 

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -4,6 +4,8 @@ import { useEffect, Children } from 'react'
 import Header from '../config'
 import dynamic from 'next/dynamic'
 import Dom from '@/components/layout/_dom'
+import { A11yUserPreferences } from "@react-three/a11y"
+
 import '@/styles/index.css'
 
 let LCanvas = null
@@ -42,10 +44,16 @@ function MyApp({ Component, pageProps }) {
     useStore.setState({ router })
   }, [router])
 
-  return r3fArr.length > 0 ? (
-    <SplitApp canvas={r3fArr} dom={compArr} />
-  ) : (
-    <Component {...pageProps} />
+  return (
+    <A11yUserPreferences>
+    {
+      r3fArr.length > 0 ? (
+        <SplitApp canvas={r3fArr} dom={compArr} />
+      ) : (
+        <Component {...pageProps} />
+      )
+    }
+    </A11yUserPreferences>
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1087,18 +1087,18 @@
     "@react-spring/core" "9.0.0-rc.3"
     "@react-spring/shared" "9.0.0-rc.3"
 
-"@react-three/a11y@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@react-three/a11y/-/a11y-1.0.0.tgz#deb5f2452f5fcbc51a818546da97e4cbd5d1ea5c"
-  integrity sha512-xcsqb+bG1QTtb38/efkLo9oacx5XZ8RQnIfqrzKne7vIlIMTLwZU0RO6MxomzBL6GM1Y/SJhBK9kTouiSu6WTw==
+"@react-three/a11y@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@react-three/a11y/-/a11y-1.0.1.tgz#5271d4ace3d3958251c0325fb97f40009e1beb22"
+  integrity sha512-/cS5aRl2oM0E3zy7lfA2ld8w2Hzk3TbbCMJjRXGCQ0VIz0Wf4n/2c2jYxYABC60nfvHyvjmbLxu4Y9M8WGezjg==
   dependencies:
-    "@react-three/drei" "4.0.0-beta.3"
+    utility-types "^3.10.0"
     zustand "^3.2.0"
 
-"@react-three/drei@4.0.0-beta.3", "@react-three/drei@^4.0.0-beta.3":
-  version "4.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@react-three/drei/-/drei-4.0.0-beta.3.tgz#cdfc2b070d3c7ffa6887a55ecdc74ec064dd8682"
-  integrity sha512-itYdOz4g6ahH+z6SC7zELKskiNlFMoYsKuJZg3+3wc5pkBQXsJuDgQ9FvW0kKSIsSm8+2yvOa4QAKzqxzQ/C5A==
+"@react-three/drei@^4.0.0-beta.4":
+  version "4.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@react-three/drei/-/drei-4.0.0-beta.4.tgz#a27f577de289ebf3d1c121808bdb04a8ae90afa3"
+  integrity sha512-NzW86lxqPv/vXE++tat4ZfupDptbHK72onn9YrkJiE3F/2l/uWNpid+OFHVockzKnzf50wDYi31Zcu9ZUigXew==
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@react-spring/web" "^9.0.0-rc.3"
@@ -2343,6 +2343,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -2354,7 +2361,7 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1087,7 +1087,15 @@
     "@react-spring/core" "9.0.0-rc.3"
     "@react-spring/shared" "9.0.0-rc.3"
 
-"@react-three/drei@^4.0.0-beta.3":
+"@react-three/a11y@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@react-three/a11y/-/a11y-1.0.0.tgz#deb5f2452f5fcbc51a818546da97e4cbd5d1ea5c"
+  integrity sha512-xcsqb+bG1QTtb38/efkLo9oacx5XZ8RQnIfqrzKne7vIlIMTLwZU0RO6MxomzBL6GM1Y/SJhBK9kTouiSu6WTw==
+  dependencies:
+    "@react-three/drei" "4.0.0-beta.3"
+    zustand "^3.2.0"
+
+"@react-three/drei@4.0.0-beta.3", "@react-three/drei@^4.0.0-beta.3":
   version "4.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/@react-three/drei/-/drei-4.0.0-beta.3.tgz#cdfc2b070d3c7ffa6887a55ecdc74ec064dd8682"
   integrity sha512-itYdOz4g6ahH+z6SC7zELKskiNlFMoYsKuJZg3+3wc5pkBQXsJuDgQ9FvW0kKSIsSm8+2yvOa4QAKzqxzQ/C5A==
@@ -7119,7 +7127,7 @@ zstddec@^0.0.2:
   resolved "https://registry.yarnpkg.com/zstddec/-/zstddec-0.0.2.tgz#57e2f28dd1ff56b750e07d158a43f0611ad9eeb4"
   integrity sha512-DCo0oxvcvOTGP/f5FA6tz2Z6wF+FIcEApSTu0zV5sQgn9hoT5lZ9YRAKUraxt9oP7l4e8TnNdi8IZTCX6WCkwA==
 
-zustand@^3.0.3, zustand@^3.3.3:
+zustand@^3.0.3, zustand@^3.2.0, zustand@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.3.3.tgz#88b930a873d0f13e406f96958c1409645ea8b370"
   integrity sha512-KTN/O76rVc9muDoprsCDe/LQjbuq+GHYt5JdYahuXaGZ+8Gyk44SepzTFeQTF5J+b8+/Q+o90BaSEQ3WImKPog==


### PR DESCRIPTION
Here is a first basic implementation of react-three-a11y in the starter.

It allow to access the user preferences from anywhere in the app ( canvas or dom ) in order to disable animations when required or set a dark / light theme according to user needs through useUserPreferences().

I also added the A11y link component around both the sphere and cube as they act as link.

I could also change the background from dark to light or the shape colors depending on the user preferences but It's your demo so it's up to you 🙂
IMO we don't need to turn the demo in an accessibility showcase as it's a starter.

⚠I haven't been able to make react-three-a11y work without transpilation. I'm using react-three-a11y@1.0.0 and this version have @react-three/drei@4.0.0-beta.3 as a dependencies and three-stdlib@1.0.0 as a peer dependencies. 
 And yet it still shows compilation error
```
 error - C:\Users\a.baraou\Desktop\projets\tempproj\react-three-next\node_modules\@react-three\drei\web\Html.js:1
import _extends from '@babel/runtime/helpers/esm/extends';
^^^^^^

SyntaxError: Cannot use import statement outside a module 
```
 Because of this I haven't tested the implementation yet.
 
I'm hoping you'll know where the error comes from so I didn't look any further so far. 

I'm available to do any change to the a11y implementation if you have something else in mind.