### PR TITLE
eslint files path fix for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": false,
   "scripts": {
     "lint": "yarn prettier && yarn eslint",
-    "eslint": "eslint --fix 'src/**/*.{js,jsx}' --ext jsconfig.json",
+    "eslint": "eslint --fix \"src/**/*.{js,jsx}\" --ext jsconfig.json",
     "prettier": "prettier --list-different '**/*.{js,jsx,md}'",
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Like we discussed, I changed the single quote to double quote in order to make it works in windows.