### PR TITLE
TS Build Fix + shader extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,5 +6,6 @@
     "dbaeumer.vscode-eslint",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
+    "slevesque.shader"
   ]
 }

--- a/src/components/canvas/Shader/Shader.jsx
+++ b/src/components/canvas/Shader/Shader.jsx
@@ -5,7 +5,6 @@ import useStore from '@/helpers/store'
 import { shaderMaterial } from '@react-three/drei'
 import guid from 'short-uuid'
 
-// @ts-ignore
 import vertex from './glsl/shader.vert'
 import fragment from './glsl/shader.frag'
 
@@ -20,6 +19,7 @@ const ColorShiftMaterial = shaderMaterial(
 
 // This is the 🔑 that HMR will renew if this file is edited
 // It works for THREE.ShaderMaterial as well as for drei/shaderMaterial
+// @ts-ignore
 ColorShiftMaterial.key = guid.generate()
 
 extend({ ColorShiftMaterial })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,9 @@
+declare module '*.vert' {
+  const content: string
+  export default content
+}
+
+declare module '*.frag' {
+  const content: string
+  export default content
+}

--- a/src/pages/box.jsx
+++ b/src/pages/box.jsx
@@ -24,6 +24,7 @@ const Page = () => {
   return (
     <>
       <DOM />
+      {/* @ts-ignore */}
       <R3F r3f />
     </>
   )


### PR DESCRIPTION
Fixes a `@ts-ignore` and adds some others to get `npm run build` working with typescript again. Was unsure if adding a type definition file to an otherwise JavaScript repo is fine, but it *felt better* than more `@ts-ignore` + it typed the import in JavaScript too 🤷 

Also added [Shader languages support for VS Code](https://marketplace.visualstudio.com/items?itemName=slevesque.shader) to the recommendations as it seemed fine enough to me even though I know nothing about shaders