### PR TITLE
Always balance page children

### DIFF
--- a/src/helpers/partition.js
+++ b/src/helpers/partition.js
@@ -1,4 +1,7 @@
 function partition(array, isValid) {
+  if (!Array.isArray(array)) {
+    return isValid(array) ? [[array], []] : [[], [array]];
+  }
   return array.reduce(
     ([pass, fail], elem) => {
       return isValid(elem) ? [[...pass, elem], fail] : [pass, [...fail, elem]]

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -30,15 +30,11 @@ function App({ Component, pageProps = { title: 'index' } }) {
   }, [router])
 
   const child = Component(pageProps).props.children
-
+  
   return (
     <>
       <Header title={pageProps.title} />
-      {child && child.length > 1 ? (
-        <Balance child={Component(pageProps).props.children} />
-      ) : (
-        <Component {...pageProps} />
-      )}
+      <Balance child={child} />
     </>
   )
 }


### PR DESCRIPTION
Balancing the nodes inside the split function allows that if the only children is a r3f scene, it renders it inside the Canvas layout. Right now if there is only 1 children it's always rendered as a DOM node.