### PR TITLE
Only render LCanvas when r3f prop is defined and allow to pass page props to r3f prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ yarn create r3f-app next my-app -ts
 Inform the nextjs page that the component is a Threejs component. For that, simply add the **r3f** property to the parent component.
 
 ```jsx
-const Page = () => {
+const Page = (props) => {
   return (
     <>
       <div>Hello !</div>
@@ -56,7 +56,8 @@ const Page = () => {
   )
 }
 // canvas components goes here
-Page.r3f = (
+// It will receive same props as Page component (from getStaticProps, etc.)
+Page.r3f = (props) => (
   <>
     <Shader />
   </>

--- a/src/components/layout/canvas.jsx
+++ b/src/components/layout/canvas.jsx
@@ -8,8 +8,14 @@ const LControl = () => {
   const control = useRef(null)
 
   useEffect(() => {
-    if (control) {
-      dom.current.style['touch-action'] = 'none'
+    if (control.current) {
+      const domElement = dom.current
+      const originalTouchAction = domElement.style['touch-action'] 
+      domElement.style['touch-action'] = 'none'
+
+      return () => {
+        domElement.style['touch-action'] = originalTouchAction
+      }
     }
   }, [dom, control])
   // @ts-ignore

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -23,7 +23,7 @@ function App({ Component, pageProps = { title: 'index' } }) {
       <Dom>
         <Component {...pageProps} />
       </Dom>
-      <LCanvas>{Component?.r3f}</LCanvas>
+      {Component?.r3f && <LCanvas>{Component.r3f}</LCanvas>}
     </>
   )
 }

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -23,7 +23,7 @@ function App({ Component, pageProps = { title: 'index' } }) {
       <Dom>
         <Component {...pageProps} />
       </Dom>
-      {Component?.r3f && <LCanvas>{Component.r3f}</LCanvas>}
+      {Component?.r3f && <LCanvas>{Component.r3f(pageProps)}</LCanvas>}
     </>
   )
 }

--- a/src/pages/box.jsx
+++ b/src/pages/box.jsx
@@ -6,14 +6,15 @@ const Box = dynamic(() => import('@/components/canvas/Box'), {
 })
 
 // Step 5 - delete Instructions components
-const Page = () => {
+const Page = (props) => {
   return (
     <>
       <Instructions />
     </>
   )
 }
-Page.r3f = (
+
+Page.r3f = (props) => (
   <>
     <Box route='/' />
   </>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -12,7 +12,7 @@ const Shader = dynamic(() => import('@/components/canvas/Shader/Shader'), {
 })
 
 // dom components goes here
-const Page = () => {
+const Page = (props) => {
   return (
     <>
       <Instructions />
@@ -21,7 +21,8 @@ const Page = () => {
 }
 
 // canvas components goes here
-Page.r3f = (
+// It will receive same props as Page component (from getStaticProps, etc.)
+Page.r3f = (props) => (
   <>
     <Shader />
   </>


### PR DESCRIPTION
This PR makes two changes:
1. Conditionally render `LCanvas` component. It will only render if `r3f` is defined in the page. Resolve #74 
2. Convert `r3f` prop into a function. This allows to pass `pageProps` in `_app.jsx` into the R3F tree and get access to all the props obtained from `getStaticProps`, `getServerSideProps`, etc.