### PR TITLE
Typo in pages/blob.jsx

### DIFF
--- a/src/pages/blob.jsx
+++ b/src/pages/blob.jsx
@@ -6,7 +6,7 @@ const Blob = dynamic(() => import('@/components/canvas/Blob'), { ssr: false })
 export default function Page(props) {
   return (
     <Instructions>
-      This is the <span className='text-green-200'>/blob</span> route. Click on the box to navigate back. The canvas was
+      This is the <span className='text-green-200'>/blob</span> route. Click on the blob to navigate back. The canvas was
       not unmounted between route changes, only its contents. If you want scene contents to persist, put them into{' '}
       <span className='text-green-200'>@/components/canvas/Canvas</span>.
     </Instructions>


### PR DESCRIPTION
It says "click on the box to go back." Shouldn't it say "blob"? 

Otherwise, the new look is a big improvement on the default cube! 👌