### PR TITLE
Open graph meta tags are wrong and lead to issues when sharing page on Social Media

### DIFF
--- a/src/config.jsx
+++ b/src/config.jsx
@@ -28,12 +28,12 @@ export default function Header({ title = titleDefault }) {
       {/* 
       Facebook Open Graph meta tags
         documentation: https://developers.facebook.com/docs/sharing/opengraph */}
-      <meta name='og:title' content={title} />
-      <meta name='og:type' content='site' />
-      <meta name='og:url' content={url} />
-      <meta name='og:image' content={'/icons/share.png'} />
-      <meta name='og:site_name' content={title} />
-      <meta name='og:description' content={description} />
+      <meta property='og:title' content={title} />
+      <meta property='og:type' content='site' />
+      <meta property='og:url' content={url} />
+      <meta property='og:image' content={'/icons/share.png'} />
+      <meta property='og:site_name' content={title} />
+      <meta property='og:description' content={description} />
 
       <link rel='apple-touch-icon' href='/icons/apple-touch-icon.png' />
       <link rel='apple-touch-icon' sizes='16x16' href='/icons/favicon-16x16.png' />


### PR DESCRIPTION
The open graph meta tags in config.tsx should implement the 'property' attribute instead of 'name' to be fully compliant with [open graph requirements](https://ogp.me/). I noticed that LinkedIn image preview is not working when using the 'name' attribute. Also Facebook is complaining and stating
"The 'og:image' property should be explicitly provided, even if a value can be inferred from other tags."

[LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/inspect/)
[Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)

These issues go away after switching to 'property' on the OG meta tags. LinkedIn displays open graph images correctly after this change. Twitter, however, is fine with using the 'name' attribute which is confirmed in their documentation.