### PR TITLE
refactor: remove redundant key creation

### DIFF
--- a/src/templates/Shader/Shader.jsx
+++ b/src/templates/Shader/Shader.jsx
@@ -15,11 +15,6 @@ const ShaderImpl = shaderMaterial(
   fragment,
 )
 
-// This is the 🔑 that HMR will renew if this file is edited
-// It works for THREE.ShaderMaterial as well as for drei/shaderMaterial
-// @ts-ignore
-ShaderImpl.key = THREE.MathUtils.generateUUID()
-
 extend({ ShaderImpl })
 
 // eslint-disable-next-line react/display-name


### PR DESCRIPTION
As checked with `drei` library the key parameter is already generated within the `shaderMaterial` function, so do we really need to create it again? 

https://github.com/pmndrs/drei/blob/17eb192955f2fa93ce86aefbdf6c40a7965a6f8f/src/core/shaderMaterial.tsx#L56

```js
  material.key = THREE.MathUtils.generateUUID()
  return material
```