### PR TITLE
fix: bump NextJS to v13.4.2 to resolve #133

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@react-three/drei": "^9.65.3",
     "@react-three/fiber": "^8.12.0",
     "glsl-random": "^0.0.5",
-    "next": "^13.3.0",
+    "next": "^13.4.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "three": "^0.151.3",


### PR DESCRIPTION
Hi, when running `yarn create r3f-app next my-app` I encountered #133. As described in the issue, the error originates from next.js [vercel/next.js#48651](https://github.com/vercel/next.js/discussions/48651).

Updating to the latest next.js version (v13.4.2) resolves this issue.