### PR TITLE
Apparent small typo on main page

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -70,7 +70,7 @@ export default function Page() {
         <div className='w-full p-6 sm:w-1/2'>
           <h2 className='mb-3 text-3xl font-bold leading-none text-gray-800'>Dom and 3D are synchronized</h2>
           <p className='mb-8 text-gray-600'>
-            3D Divs are renderer through the View component. It uses gl.scissor to cut the viewport into segments. You
+            3D Divs are rendered through the View component. It uses gl.scissor to cut the viewport into segments. You
             tie a view to a tracking div which then controls the position and bounds of the viewport. This allows you to
             have multiple views with a single, performant canvas. These views will follow their tracking elements,
             scroll along, resize, etc.


### PR DESCRIPTION
Was about to use this project to initialize a ThreeJS environment, and saw what appeared to be a small typo on the main page.

As far as I could tell, the word `renderer` should've actually been `rendered`. This PR is nothing more than changing this single letter to fix this typo.